### PR TITLE
Add registros table view with filtering

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,28 +1,22 @@
 <script lang="ts">
-  import Card from './components/card.svelte';
-  import Counter from './components/Counter.svelte'
-  import { horarioDeUmaData, horarioParaString } from './components/functions';
-  import {Registros} from './components/store';
+  import Counter from './components/Counter.svelte';
+  import RegistrosPage from './components/RegistrosPage.svelte';
+
+  let view: 'home' | 'registros' = 'home';
 
 </script>
 
-<main>
-  <div class="card">
-    <Counter />
-  </div>
+<main class="p-4 space-y-4">
+  <nav class="space-x-4">
+    <button class="px-3 py-1 border rounded" on:click={() => (view = 'home')}>Início</button>
+    <button class="px-3 py-1 border rounded" on:click={() => (view = 'registros')}>Registros</button>
+  </nav>
 
-  {#if $Registros.length !== 0}
-  <div class="flex flex-col"> 
-      <h1 class="text-lg"> Seu registro de trabalho: </h1>
-      <div>
-        {#each $Registros as {dia, inicio, horasTrabalhadas}}
-          <Card 
-            dia={dia} 
-            inicio={horarioParaString(horarioDeUmaData(inicio))}
-            horasTrabalhadas={horarioParaString(horasTrabalhadas)}
-          />
-        {/each}
-      </div>
-  </div>
+  {#if view === 'home'}
+    <div class="card">
+      <Counter />
+    </div>
+  {:else if view === 'registros'}
+    <RegistrosPage />
   {/if}
 </main>

--- a/src/components/Counter.svelte
+++ b/src/components/Counter.svelte
@@ -21,7 +21,7 @@
     $Registros = [
       ...$Registros,
       {
-        id: Date.now(),
+        id: crypto.randomUUID(),
         dia,
         inicio,
         termino,

--- a/src/components/Counter.svelte
+++ b/src/components/Counter.svelte
@@ -18,12 +18,16 @@
 
     const termino = new Date();
 
-    $Registros = [...$Registros, {
-      dia,
-      inicio,
-      termino,
-      horasTrabalhadas: horasTrabalhadas(inicio, termino),
-    }];
+    $Registros = [
+      ...$Registros,
+      {
+        id: Date.now(),
+        dia,
+        inicio,
+        termino,
+        horasTrabalhadas: horasTrabalhadas(inicio, termino),
+      },
+    ];
   }
 
 </script>

--- a/src/components/RegistrosPage.svelte
+++ b/src/components/RegistrosPage.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { Registros } from './store';
+  import { horarioDeUmaData, horarioParaString } from './functions';
+  import { derived } from 'svelte/store';
+
+  let filtro = '';
+
+  const filtrados = derived([Registros], ([$Registros]) =>
+    $Registros.filter((r) => r.dia.includes(filtro))
+  );
+</script>
+
+<div class="space-y-2">
+  <input
+    type="text"
+    placeholder="Filtrar por dia"
+    bind:value={filtro}
+    class="border p-1 rounded"
+  />
+
+  <table class="min-w-full table-auto border">
+    <thead>
+      <tr class="bg-gray-100">
+        <th class="px-2 border">ID</th>
+        <th class="px-2 border">Dia</th>
+        <th class="px-2 border">Início</th>
+        <th class="px-2 border">Horas trabalhadas</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each $filtrados as registro (registro.id)}
+        <tr class="text-center border-t">
+          <td class="px-2 border">{registro.id}</td>
+          <td class="px-2 border">{registro.dia}</td>
+          <td class="px-2 border">{horarioParaString(horarioDeUmaData(registro.inicio))}</td>
+          <td class="px-2 border">{horarioParaString(registro.horasTrabalhadas)}</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>

--- a/src/components/RegistrosPage.svelte
+++ b/src/components/RegistrosPage.svelte
@@ -18,7 +18,7 @@
     class="border p-1 rounded"
   />
 
-  <table class="min-w-full table-auto border-collapse border rounded-lg overflow-hidden">
+  <table class="min-w-full table-auto border-collapse border rounded-lg overflow-hidden text-black">
     <thead class="bg-gray-100">
       <tr>
         <th class="px-3 py-2 border">ID</th>

--- a/src/components/RegistrosPage.svelte
+++ b/src/components/RegistrosPage.svelte
@@ -18,22 +18,24 @@
     class="border p-1 rounded"
   />
 
-  <table class="min-w-full table-auto border">
-    <thead>
-      <tr class="bg-gray-100">
-        <th class="px-2 border">ID</th>
-        <th class="px-2 border">Dia</th>
-        <th class="px-2 border">Início</th>
-        <th class="px-2 border">Horas trabalhadas</th>
+  <table class="min-w-full table-auto border-collapse border rounded-lg overflow-hidden">
+    <thead class="bg-gray-100">
+      <tr>
+        <th class="px-3 py-2 border">ID</th>
+        <th class="px-3 py-2 border">Dia</th>
+        <th class="px-3 py-2 border">Início</th>
+        <th class="px-3 py-2 border">Término</th>
+        <th class="px-3 py-2 border">Horas trabalhadas</th>
       </tr>
     </thead>
     <tbody>
       {#each $filtrados as registro (registro.id)}
-        <tr class="text-center border-t">
-          <td class="px-2 border">{registro.id}</td>
-          <td class="px-2 border">{registro.dia}</td>
-          <td class="px-2 border">{horarioParaString(horarioDeUmaData(registro.inicio))}</td>
-          <td class="px-2 border">{horarioParaString(registro.horasTrabalhadas)}</td>
+        <tr class="text-center odd:bg-white even:bg-gray-50 border-t">
+          <td class="px-3 py-1 border font-mono text-sm">{registro.id}</td>
+          <td class="px-3 py-1 border">{registro.dia}</td>
+          <td class="px-3 py-1 border">{horarioParaString(horarioDeUmaData(registro.inicio))}</td>
+          <td class="px-3 py-1 border">{horarioParaString(horarioDeUmaData(registro.termino))}</td>
+          <td class="px-3 py-1 border">{horarioParaString(registro.horasTrabalhadas)}</td>
         </tr>
       {/each}
     </tbody>

--- a/src/components/store.ts
+++ b/src/components/store.ts
@@ -1,7 +1,7 @@
 import { writable, type Writable } from "svelte/store";
 
 export interface Registro {
-  id: number;
+  id: string;
   dia: string;
   inicio: Date;
   termino: Date;

--- a/src/components/store.ts
+++ b/src/components/store.ts
@@ -1,6 +1,7 @@
 import { writable, type Writable } from "svelte/store";
 
 export interface Registro {
+  id: number;
   dia: string;
   inicio: Date;
   termino: Date;


### PR DESCRIPTION
## Summary
- add `id` field to Registro type
- track id in Counter logic
- create a RegistrosPage for filtering and listing records
- update App to navigate between counter and registros page

## Testing
- `npx tsc -p tsconfig.json`
- `yarn check` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6840e8154b28832ea1414271031c8ff4