### PR TITLE
Fix Navbar layout

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
   import Counter from './components/Counter.svelte';
   import RegistrosPage from './components/RegistrosPage.svelte';
+  import Navbar from './components/Navbar.svelte';
 
   let view: 'home' | 'registros' = 'home';
 
 </script>
 
-<main class="p-4 space-y-4">
-  <nav class="space-x-4">
-    <button class="px-3 py-1 border rounded" on:click={() => (view = 'home')}>Início</button>
-    <button class="px-3 py-1 border rounded" on:click={() => (view = 'registros')}>Registros</button>
-  </nav>
+<Navbar {view} on:change={(e) => (view = e.detail.view)} />
+
+<main class="p-4 pt-16 space-y-4">
 
   {#if view === 'home'}
     <div class="card">

--- a/src/components/Navbar.svelte
+++ b/src/components/Navbar.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  export let view: 'home' | 'registros';
+
+  const dispatch = createEventDispatcher<{ change: { view: 'home' | 'registros' } }>();
+
+  function select(target: 'home' | 'registros') {
+    dispatch('change', { view: target });
+  }
+</script>
+
+<nav class="fixed top-0 left-0 w-full flex gap-4 p-2 bg-gray-800 text-white">
+  <button
+    class="px-3 py-1 border rounded"
+    class:bg-blue-500={view === 'home'}
+    class:text-white={view === 'home'}
+    on:click={() => select('home')}
+  >
+    Início
+  </button>
+
+  <button
+    class="px-3 py-1 border rounded"
+    class:bg-blue-500={view === 'registros'}
+    class:text-white={view === 'registros'}
+    on:click={() => select('registros')}
+  >
+    Registros
+  </button>
+</nav>


### PR DESCRIPTION
## Summary
- revert Yarn 2 artifacts and restore previous lockfile
- position Navbar at top-left of the screen
- shift main content down to avoid overlap

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6840ee04f488832e8055935ad20fd985