### PR TITLE
Add global work status with timer

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,8 +2,37 @@
   import Counter from './components/Counter.svelte';
   import RegistrosPage from './components/RegistrosPage.svelte';
   import Navbar from './components/Navbar.svelte';
+  import { StatusTrabalho } from './components/store';
+  import { onDestroy } from 'svelte';
 
   let view: 'home' | 'registros' = 'home';
+
+  let interval: any;
+
+  function atualizarTitulo() {
+    const { trabalhando, inicio } = $StatusTrabalho;
+    if (trabalhando && inicio) {
+      const agora = new Date();
+      const diff = new Date(agora.getTime() - new Date(inicio).getTime());
+      const hh = String(diff.getUTCHours()).padStart(2, '0');
+      const mm = String(diff.getUTCMinutes()).padStart(2, '0');
+      const ss = String(diff.getUTCSeconds()).padStart(2, '0');
+      document.title = `🎯 ${hh}:${mm}:${ss}`;
+    }
+  }
+
+  $: {
+    const { trabalhando, inicio } = $StatusTrabalho;
+    clearInterval(interval);
+    if (trabalhando && inicio) {
+      atualizarTitulo();
+      interval = setInterval(atualizarTitulo, 1000);
+    } else {
+      document.title = '💤 aguardando...';
+    }
+  }
+
+  onDestroy(() => clearInterval(interval));
 
 </script>
 

--- a/src/components/Counter.svelte
+++ b/src/components/Counter.svelte
@@ -1,18 +1,20 @@
 <script lang="ts">
-  import { Registros } from './store';
-
+  import { Registros, StatusTrabalho } from './store';
   import { horasTrabalhadas } from './functions';
+  import { get } from 'svelte/store';
 
-  let trabalhando: boolean = false;
-  let inicio: Date;
-  let dia: string;
+  $: trabalhando = $StatusTrabalho.trabalhando;
 
   function mudarStatusDeTrabalho() {
-    trabalhando = !trabalhando;
-    
-    if(trabalhando){
-      inicio = new Date()
-      dia = `${inicio.getDate()}/${inicio.getMonth() + 1}/${inicio.getFullYear()}`;
+    const status = get(StatusTrabalho);
+
+    if (!status.trabalhando) {
+      const inicio = new Date();
+      StatusTrabalho.set({
+        trabalhando: true,
+        inicio,
+        dia: `${inicio.getDate()}/${inicio.getMonth() + 1}/${inicio.getFullYear()}`,
+      });
       return;
     }
 
@@ -22,12 +24,14 @@
       ...$Registros,
       {
         id: crypto.randomUUID(),
-        dia,
-        inicio,
+        dia: status.dia!,
+        inicio: status.inicio!,
         termino,
-        horasTrabalhadas: horasTrabalhadas(inicio, termino),
+        horasTrabalhadas: horasTrabalhadas(status.inicio!, termino),
       },
     ];
+
+    StatusTrabalho.set({ trabalhando: false, inicio: null, dia: null });
   }
 
 </script>

--- a/src/components/store.ts
+++ b/src/components/store.ts
@@ -15,3 +15,15 @@ export interface Horario {
 }
 
 export const Registros: Writable<Registro[]> = writable([]);
+
+export interface StatusTrabalho {
+  trabalhando: boolean;
+  inicio: Date | null;
+  dia: string | null;
+}
+
+export const StatusTrabalho: Writable<StatusTrabalho> = writable({
+  trabalhando: false,
+  inicio: null,
+  dia: null,
+});


### PR DESCRIPTION
## Summary
- manage work status in `StatusTrabalho` store
- update Counter to use global store
- update App to change `<title>` showing work timer

## Testing
- `yarn check`

------
https://chatgpt.com/codex/tasks/task_e_6840f134e844832eb2ec5f10018cbeb4